### PR TITLE
update SPARK_WORKER_MEMORY to 1g to fix resource issues on both Win11 and Linux

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
     container_name: spark-worker-1
     environment:
       - SPARK_WORKER_CORES=1
-      - SPARK_WORKER_MEMORY=512m
+      - SPARK_WORKER_MEMORY=1g
     ports:
       - 8081:8081
     volumes:
@@ -41,7 +41,7 @@ services:
     container_name: spark-worker-2
     environment:
       - SPARK_WORKER_CORES=1
-      - SPARK_WORKER_MEMORY=512m
+      - SPARK_WORKER_MEMORY=1g
     ports:
       - 8082:8081
     volumes:


### PR DESCRIPTION
## Introduction

Hi there, thanks for helping the project! We are doing our best to help the community to learn and practice
parallel computing in distributed environments through our projects. :sparkles:

## Pull Request

### Issue

- #92

### Changes

- Increase memory from 512m to 1g - this fix works on both Windows 11 and Linux

### Comments (optional)

- I can test on Mac OS during December 2024 - just waiting for my new workstation

### Checklist

Please make sure to check the following:

- [x] I have followed the steps in the [CONTRIBUTING.md](../CONTRIBUTING.md) file.
- [x] I am aware that pull requests that do not follow the rules will be automatically rejected.
